### PR TITLE
git status エイリアスに --short --branch オプションを追加

### DIFF
--- a/git-alias.zsh
+++ b/git-alias.zsh
@@ -38,7 +38,7 @@ alias grv='git remote -v'
 alias gpd='git push -d'
 
 # git status
-alias gs='git status'
+alias gs='git status --short --branch'
 
 # git switch
 alias gsw='git switch'


### PR DESCRIPTION
# 概要

`gs` エイリアスの `git status` コマンドに `--short --branch` オプションを追加しました。

# 背景

`git status` の出力をより簡潔で読みやすくするため、短形式表示とブランチ情報の表示を常に有効にします。

# 内容

- `alias gs='git status'` を `alias gs='git status --short --branch'` に変更
- `--short`: ステータスを短形式で表示（M、A、D などの記号で変更を表示）
- `--branch`: 現在のブランチとトラッキング情報を表示

# 確認ポイント

- `gs` コマンドで短形式のステータスが表示されることを確認
- ブランチ情報が正しく表示されることを確認

https://claude.ai/code/session_01XTpMKxcASTppJSS8dkCoHa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 変更内容

* **Chores**
  * Git ステータスコマンドのエイリアスを更新しました。新しい形式では、ブランチ情報を含むより簡潔な出力が表示されるようになります。ステータス確認の操作がより効率的になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->